### PR TITLE
Enable Allauth-based email authentication

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,6 +8,7 @@ whitenoise  # https://github.com/evansd/whitenoise
 django  # pyup: < 4.2  # https://www.djangoproject.com/
 django-environ  # https://github.com/joke2k/django-environ
 django-model-utils  # https://github.com/jazzband/django-model-utils
+django-allauth  # https://github.com/pennersr/django-allauth
 # Django REST Framework
 djangorestframework  # https://github.com/encode/django-rest-framework
 django-cors-headers  # https://github.com/adamchainz/django-cors-headers

--- a/src/propylon_document_manager/site/settings/base.py
+++ b/src/propylon_document_manager/site/settings/base.py
@@ -69,11 +69,14 @@ DJANGO_APPS = [
     # "django.contrib.humanize", # Handy template tags
     "django.contrib.admin",
     "django.forms",
+    "django.contrib.sites",
 ]
 THIRD_PARTY_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
     "corsheaders",
+    "allauth",
+    "allauth.account",
 ]
 
 LOCAL_APPS = [
@@ -87,7 +90,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 # MIGRATIONS
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#migration-modules
-MIGRATION_MODULES = {"sites": "propylon_document_manager.contrib.sites.migrations"}
+MIGRATION_MODULES = {"sites": "django.contrib.sites.migrations"}
 
 # AUTHENTICATION
 # ------------------------------------------------------------------------------
@@ -96,6 +99,12 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
+# Django Allauth configuration
+ACCOUNT_AUTHENTICATION_METHOD = "email"
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_USERNAME_REQUIRED = False
+ACCOUNT_USER_MODEL_USERNAME_FIELD = None
+ACCOUNT_EMAIL_VERIFICATION = "none"
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-user-model
 AUTH_USER_MODEL = "file_versions.User"
 # https://docs.djangoproject.com/en/dev/ref/settings/#login-url


### PR DESCRIPTION
## Summary
- add django-allauth dependency
- configure settings for Allauth email login

## Testing
- `pip install django-allauth` *(fails: Could not find a version that satisfies the requirement django-allauth)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pre-commit run --files requirements/base.in src/propylon_document_manager/site/settings/base.py` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b1b02964832e8e4c23ba5d57cc2c