### PR TITLE
Add missing AccountMiddleware to settings

### DIFF
--- a/src/propylon_document_manager/site/settings/base.py
+++ b/src/propylon_document_manager/site/settings/base.py
@@ -140,6 +140,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]


### PR DESCRIPTION
## Summary
- include `allauth.account.middleware.AccountMiddleware` in base settings

## Testing
- `pre-commit run --files src/propylon_document_manager/site/settings/base.py` *(fails: pre-commit not installed)*
- `pip install pre-commit` *(fails: Could not find a version due to proxy restrictions)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements/dev.txt` *(fails: Could not find version due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c4da444048832e8c80c2346dcf6c5a