### PR TITLE
Restore Allauth and address missing EmailAddress table

### DIFF
--- a/src/propylon_document_manager/accounts/views.py
+++ b/src/propylon_document_manager/accounts/views.py
@@ -32,7 +32,10 @@ class LoginView(APIView):
             if user:
                 token, _ = Token.objects.get_or_create(user=user)
                 return Response({"token": token.key})
-            return Response({"detail": "Invalid credentials."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "Invalid email address or password."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 


### PR DESCRIPTION
## Summary
- reintroduce django-allauth and related dependencies
- restore allauth apps, middleware, and authentication backends
- improve login error message for clarity

## Testing
- `pip install -r requirements/dev.txt` *(fails: Could not find a version that satisfies the requirement argon2-cffi==23.1.0)*
- `pre-commit run --files requirements/base.in requirements/dev.txt src/propylon_document_manager/accounts/views.py src/propylon_document_manager/site/settings/base.py` *(fails: command not found: pre-commit)*
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c4db8074f8832ea6c9333ff32349ad