### PR TITLE
Add file upload/download with directory management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,6 +273,8 @@ dump.rdb
 
 ### Project template
 propylon_document_manager/media/
+files/*
+!files/.gitignore
 
 .pytest_cache/
 

--- a/client/doc-manager/src/pages/DocumentManager.tsx
+++ b/client/doc-manager/src/pages/DocumentManager.tsx
@@ -1,7 +1,163 @@
+import { useRef, useState } from 'react'
+
+interface FileItem {
+  id: number
+  file_name: string
+}
+
 export default function DocumentManager() {
+  const [directories, setDirectories] = useState<string[]>([])
+  const [selectedDir, setSelectedDir] = useState<string>('')
+  const [files, setFiles] = useState<FileItem[]>([])
+  const [selectedFile, setSelectedFile] = useState<FileItem | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [newDirName, setNewDirName] = useState('')
+  const [error, setError] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const openModal = () => {
+    setNewDirName('')
+    setError('')
+    setShowModal(true)
+  }
+
+  const closeModal = () => setShowModal(false)
+
+  const handleAddDirectory = async () => {
+    if (!newDirName) {
+      return
+    }
+    const formData = new FormData()
+    formData.append('parent', selectedDir)
+    formData.append('name', newDirName)
+    const response = await fetch('/api/file_versions/directories/', {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    })
+    if (response.ok) {
+      const newPath = selectedDir ? `${selectedDir}/${newDirName}` : newDirName
+      setDirectories([...directories, newPath])
+      closeModal()
+    } else {
+      setError('Cannot create a directory with that name.')
+    }
+  }
+
+  const triggerUpload = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files?.length) return
+    const file = e.target.files[0]
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('directory', selectedDir)
+    const response = await fetch('/api/file_versions/upload/', {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    })
+    if (response.ok) {
+      const data = await response.json()
+      setFiles([...files, data])
+    }
+    e.target.value = ''
+  }
+
+  const handleDownload = async () => {
+    if (!selectedFile) return
+    const response = await fetch(`/api/file_versions/${selectedFile.id}/download/`, {
+      credentials: 'include',
+    })
+    if (response.ok) {
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = selectedFile.file_name
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      window.URL.revokeObjectURL(url)
+    }
+  }
+
   return (
-    <div className="flex h-screen items-center justify-center bg-white">
-      <h1 className="text-2xl font-bold text-gray-900">Document Manager</h1>
+    <div className="flex h-screen border p-2 gap-2">
+      <div className="w-1/4 flex flex-col border h-full">
+        <div className="flex justify-between p-2">
+          <button onClick={openModal} className="rounded bg-blue-600 px-2 py-1 text-white">+ Dir</button>
+        </div>
+        <div className="flex-1 overflow-auto">
+          <ul className="p-2">
+            <li
+              className={`cursor-pointer p-1 ${selectedDir === '' ? 'font-bold' : ''}`}
+              onClick={() => setSelectedDir('')}
+            >
+              Root
+            </li>
+            {directories.map((dir) => {
+              const label = dir.split('/').slice(-1)[0]
+              return (
+                <li
+                  key={dir}
+                  className={`cursor-pointer p-1 ${selectedDir === dir ? 'font-bold' : ''}`}
+                  onClick={() => setSelectedDir(dir)}
+                >
+                  {label}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+        <div className="p-2">
+          <button onClick={triggerUpload} className="rounded bg-green-600 px-2 py-1 text-white">Upload</button>
+          <input ref={fileInputRef} type="file" className="hidden" onChange={handleUpload} />
+        </div>
+      </div>
+      <div className="flex-1 flex flex-col border h-full">
+        <div className="flex-1 overflow-auto">
+          <ul className="p-2">
+            {files.map((file) => (
+              <li
+                key={file.id}
+                className={`cursor-pointer p-1 ${selectedFile?.id === file.id ? 'bg-gray-200' : ''}`}
+                onClick={() => setSelectedFile(file)}
+              >
+                {file.file_name}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="p-2 flex justify-end">
+          <button
+            onClick={handleDownload}
+            disabled={!selectedFile}
+            className="rounded bg-blue-600 px-2 py-1 text-white disabled:opacity-50"
+          >
+            Download
+          </button>
+        </div>
+      </div>
+      {showModal && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+          <div className="w-80 rounded bg-white p-4">
+            <label className="mb-2 block text-sm font-medium">Add New Directory</label>
+            <input
+              className="mb-4 w-full rounded border p-2"
+              value={newDirName}
+              onChange={(e) => setNewDirName(e.target.value)}
+            />
+            {error && <p className="mb-2 text-sm text-red-600">{error}</p>}
+            <div className="flex justify-end space-x-2">
+              <button onClick={closeModal} className="rounded bg-gray-300 px-3 py-1">Cancel</button>
+              <button onClick={handleAddDirectory} className="rounded bg-blue-600 px-3 py-1 text-white">Add</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/files/.gitignore
+++ b/files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/propylon_document_manager/file_versions/api/views.py
+++ b/src/propylon_document_manager/file_versions/api/views.py
@@ -1,14 +1,87 @@
-from django.shortcuts import render
+import os
+from pathlib import Path
 
+from django.conf import settings
+from django.http import FileResponse
+from django.utils.encoding import smart_str
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+
+from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.mixins import RetrieveModelMixin, ListModelMixin
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
+from django.db.models import Max
 
 from ..models import FileVersion
 from .serializers import FileVersionSerializer
 
+
+@method_decorator(csrf_exempt, name="dispatch")
 class FileVersionViewSet(RetrieveModelMixin, ListModelMixin, GenericViewSet):
-    authentication_classes = []
-    permission_classes = []
+    permission_classes = [IsAuthenticated]
     serializer_class = FileVersionSerializer
     queryset = FileVersion.objects.all()
     lookup_field = "id"
+
+    def _safe_join(self, directory: str) -> Path:
+        base = Path(settings.FILES_ROOT).resolve()
+        target = (base / directory).resolve()
+        if not str(target).startswith(str(base)):
+            raise ValueError("Invalid directory path")
+        return target
+
+    @action(detail=False, methods=["post"], url_path="upload")
+    def upload(self, request):
+        uploaded_file = request.FILES.get("file")
+        directory = request.data.get("directory", "")
+        if not uploaded_file:
+            return Response({"detail": "No file provided."}, status=status.HTTP_400_BAD_REQUEST)
+
+        file_name = uploaded_file.name
+        base_name, ext = os.path.splitext(file_name)
+        last_version = (
+            FileVersion.objects.filter(file_name=file_name).aggregate(max_v=Max("version_number"))
+        )["max_v"]
+        version_number = 0 if last_version is None else last_version + 1
+
+        safe_dir = self._safe_join(directory)
+        safe_dir.mkdir(parents=True, exist_ok=True)
+        filename_with_version = f"{base_name}.{version_number}{ext}"
+        storage_path = safe_dir / filename_with_version
+        with open(storage_path, "wb+") as destination:
+            for chunk in uploaded_file.chunks():
+                destination.write(chunk)
+
+        relative_path = str(Path(directory) / filename_with_version) if directory else filename_with_version
+        file_version = FileVersion.objects.create(
+            path=relative_path, file_name=file_name, version_number=version_number
+        )
+        serializer = self.get_serializer(file_version)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=["get"], url_path="download")
+    def download(self, request, id=None):
+        file_version = self.get_object()
+        file_path = Path(settings.FILES_ROOT) / smart_str(file_version.path or "")
+        if not file_path.exists():
+            return Response({"detail": "File not found."}, status=status.HTTP_404_NOT_FOUND)
+        return FileResponse(open(file_path, "rb"), as_attachment=True, filename=file_version.file_name)
+
+    @action(detail=False, methods=["post"], url_path="directories")
+    def create_directory(self, request):
+        directory = request.data.get("parent", "")
+        name = request.data.get("name")
+        if not name:
+            return Response({"detail": "Name is required."}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            target_dir = self._safe_join(Path(directory) / name)
+            target_dir.mkdir(parents=True, exist_ok=False)
+        except Exception:
+            return Response(
+                {"detail": "Cannot create a directory with that name."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response({"path": str(Path(directory) / name)}, status=status.HTTP_201_CREATED)

--- a/src/propylon_document_manager/file_versions/migrations/0002_fileversion_path.py
+++ b/src/propylon_document_manager/file_versions/migrations/0002_fileversion_path.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("file_versions", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="fileversion",
+            name="path",
+            field=models.CharField(max_length=256, null=True),
+        ),
+    ]

--- a/src/propylon_document_manager/file_versions/models.py
+++ b/src/propylon_document_manager/file_versions/models.py
@@ -32,5 +32,6 @@ class User(AbstractUser):
 
 
 class FileVersion(models.Model):
+    path = models.fields.CharField(max_length=256, null=True)
     file_name = models.fields.CharField(max_length=512)
     version_number = models.fields.IntegerField()

--- a/src/propylon_document_manager/site/settings/base.py
+++ b/src/propylon_document_manager/site/settings/base.py
@@ -166,6 +166,9 @@ MEDIA_ROOT = str(APPS_DIR / "media")
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-url
 MEDIA_URL = "/media/"
 
+# Directory for uploaded files
+FILES_ROOT = BASE_DIR.parent / "files"
+
 # TEMPLATES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#templates


### PR DESCRIPTION
## Summary
- store uploaded files under protected `files` directory
- add `path` column and versioned upload/download API endpoints
- build DocumentManager UI with directory creation, upload, and download controls
- exempt file API from CSRF and surface directory path creation errors
- show bordered directory tree and file panels with equal heights

## Testing
- `python manage.py makemigrations file_versions` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f7f5f9fc832eb67eb467856ebaa3