### PR TITLE
Fix MUI tree view import

### DIFF
--- a/client/doc-manager/src/pages/DocumentManager.tsx
+++ b/client/doc-manager/src/pages/DocumentManager.tsx
@@ -10,7 +10,8 @@ import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import { TreeView, TreeItem } from '@mui/lab'
+import TreeView from '@mui/lab/TreeView'
+import TreeItem from '@mui/lab/TreeItem'
 
 interface FileItem {
   id: number
@@ -101,8 +102,8 @@ export default function DocumentManager() {
     <Box display="flex" height="100vh" border={1} borderColor="grey.400">
       <Box width="25%" display="flex" flexDirection="column" borderRight={1} borderColor="grey.300">
         <Box display="flex" justifyContent="space-between" alignItems="center" p={1} borderBottom={1} borderColor="grey.300">
-          <Typography variant="subtitle1">Tree</Typography>
-          <Button variant="contained" size="small" onClick={openModal}>+ dir</Button>
+          <Typography variant="subtitle1">Directories</Typography>
+          <Button variant="contained" size="small" onClick={openModal}>Add Directory</Button>
         </Box>
         <Box flexGrow={1} overflow="auto" p={1}>
           <TreeView selected={selectedDir} onNodeSelect={(_, id) => setSelectedDir(id)}>


### PR DESCRIPTION
## Summary
- import TreeView and TreeItem from their specific @mui/lab modules
- clarify directory sidebar labels

## Testing
- `pre-commit run --files client/doc-manager/src/pages/DocumentManager.tsx` *(failed: command not found)*
- `npm test` *(failed: ReferenceError: document is not defined)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c784695c1c832eb28b2e8d272f8959