### PR TITLE
fix: specify valid mui lab version

### DIFF
--- a/client/doc-manager/package.json
+++ b/client/doc-manager/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.15.14",
-    "@mui/lab": "^5.0.0",
+    "@mui/lab": "5.0.0-alpha.126",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3"


### PR DESCRIPTION
## Summary
- specify an existing `@mui/lab` prerelease version in package.json to enable installation

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: ReferenceError: document is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68c786262354832ea5fa28b5a2a6f505