### PR TITLE
Remove invalid base-ui dependency

### DIFF
--- a/client/doc-manager/package.json
+++ b/client/doc-manager/package.json
@@ -12,8 +12,6 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.15.14",
-    "@base-ui-components/react": "^1.0.0",
-    "@mui/x-tree-view": "^6.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3"

--- a/client/doc-manager/src/pages/DocumentManager.tsx
+++ b/client/doc-manager/src/pages/DocumentManager.tsx
@@ -10,8 +10,6 @@ import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView'
-import { TreeItem } from '@mui/x-tree-view/TreeItem'
 
 interface FileItem {
   id: number
@@ -106,16 +104,24 @@ export default function DocumentManager() {
           <Button variant="contained" size="small" onClick={openModal}>Add Directory</Button>
         </Box>
         <Box flexGrow={1} overflow="auto" p={1}>
-          <SimpleTreeView
-            selectedItems={[selectedDir]}
-            onSelectedItemsChange={(_, ids: string[]) => setSelectedDir(ids[0] ?? 'root')}
-          >
-            <TreeItem itemId="root" label="Root">
-              {directories.map((dir) => (
-                <TreeItem key={dir} itemId={dir} label={dir} />
-              ))}
-            </TreeItem>
-          </SimpleTreeView>
+          <List>
+            <ListItemButton
+              selected={selectedDir === 'root'}
+              onClick={() => setSelectedDir('root')}
+            >
+              <ListItemText primary="Root" />
+            </ListItemButton>
+            {directories.map((dir) => (
+              <ListItemButton
+                key={dir}
+                sx={{ pl: 2 }}
+                selected={selectedDir === dir}
+                onClick={() => setSelectedDir(dir)}
+              >
+                <ListItemText primary={dir} />
+              </ListItemButton>
+            ))}
+          </List>
         </Box>
         <Box p={1}>
           <Button variant="contained" onClick={triggerUpload}>Upload</Button>


### PR DESCRIPTION
## Summary
- remove nonexistent `@base-ui-components/react` dependency to allow frontend installs
- replace missing MUI tree view by rendering directories with a simple Material list

## Testing
- `npm install`
- `npm test` *(fails: ReferenceError: document is not defined)*
- `pre-commit run --files client/doc-manager/src/pages/DocumentManager.tsx client/doc-manager/package.json` *(fails: command not found: pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c789261184832e849af6aab68f356c