### PR TITLE
feat: align download button with upload and set list width

### DIFF
--- a/client/doc-manager/src/pages/DocumentManager.tsx
+++ b/client/doc-manager/src/pages/DocumentManager.tsx
@@ -59,15 +59,18 @@ export default function DocumentManager() {
 
   return (
     <Box display="flex" flexDirection="column" height="100vh" m={2}>
-      <Box mb={2} display="flex">
-        <Button variant="contained" onClick={triggerUpload}>Upload</Button>
-        <input ref={fileInputRef} type="file" hidden onChange={handleUpload} />
+      <Box mb={2} display="flex" justifyContent="space-between" alignItems="center">
+        <Box>
+          <Button variant="contained" onClick={triggerUpload}>Upload</Button>
+          <input ref={fileInputRef} type="file" hidden onChange={handleUpload} />
+        </Box>
+        <Button variant="contained" onClick={handleDownload} disabled={!selectedFile}>Download</Button>
       </Box>
       <Box flexGrow={1} display="flex" flexDirection="column">
         <Box mb={2}>
           <Typography variant="subtitle1">Files</Typography>
         </Box>
-        <Box flexGrow={1} overflow="auto">
+        <Box flexGrow={1} overflow="auto" sx={{ width: '128ch' }}>
           <List>
             {files.map((file) => (
               <ListItemButton
@@ -79,9 +82,6 @@ export default function DocumentManager() {
               </ListItemButton>
             ))}
           </List>
-        </Box>
-        <Box mt={2} display="flex" justifyContent="flex-end">
-          <Button variant="contained" onClick={handleDownload} disabled={!selectedFile}>Download</Button>
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- Align Download button with Upload at the top of the file list
- Constrain file list to ~128 characters in width

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c825baaf8c832eba44b08e59250393