### PR TITLE
Remove timestamps from UserFileVersion

### DIFF
--- a/src/propylon_document_manager/file_versions/migrations/0006_remove_userfileversion_datestamps.py
+++ b/src/propylon_document_manager/file_versions/migrations/0006_remove_userfileversion_datestamps.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("file_versions", "0005_userfileversion"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="userfileversion",
+            name="created_at",
+        ),
+        migrations.RemoveField(
+            model_name="userfileversion",
+            name="updated_at",
+        ),
+        migrations.RemoveField(
+            model_name="userfileversion",
+            name="deleted_at",
+        ),
+    ]

--- a/src/propylon_document_manager/file_versions/models.py
+++ b/src/propylon_document_manager/file_versions/models.py
@@ -39,9 +39,6 @@ class FileVersion(models.Model):
 class UserFileVersion(models.Model):
     fileversion = models.ForeignKey(FileVersion, on_delete=models.CASCADE)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-    deleted_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         db_table = "file_versions_user_fileversion"

--- a/tests/test_file_versions.py
+++ b/tests/test_file_versions.py
@@ -22,6 +22,3 @@ def test_user_fileversion():
     mapping = UserFileVersion.objects.create(fileversion=file_version, user=user)
     assert mapping.fileversion == file_version
     assert mapping.user == user
-    assert mapping.created_at is not None
-    assert mapping.updated_at is not None
-    assert mapping.deleted_at is None


### PR DESCRIPTION
## Summary
- drop created_at, updated_at, and deleted_at from UserFileVersion model
- add migration to remove timestamp columns from file_versions_user_fileversion table
- update tests to reflect removal of timestamp fields

## Testing
- `pre-commit run --files src/propylon_document_manager/file_versions/models.py tests/test_file_versions.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements/dev.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c833a106ec832e8d3158e40ae4966b