### PR TITLE
Remove upload functionality from document manager

### DIFF
--- a/client/doc-manager/src/pages/DocumentManager.tsx
+++ b/client/doc-manager/src/pages/DocumentManager.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import List from '@mui/material/List'
@@ -14,33 +14,11 @@ interface FileItem {
 }
 
 export default function DocumentManager() {
-  const [files, setFiles] = useState<FileItem[]>([])
+  const [files] = useState<FileItem[]>([])
   const [selectedFile, setSelectedFile] = useState<FileItem | null>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const navigate = useNavigate()
   const token = localStorage.getItem('token')
-  const authHeader = token ? { Authorization: `Token ${token}` } : {}
-
-  const triggerUpload = () => {
-    fileInputRef.current?.click()
-  }
-
-  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!e.target.files?.length) return
-    const file = e.target.files[0]
-    const formData = new FormData()
-    formData.append('file', file)
-    const response = await fetch('/api/file_versions/upload/', {
-      method: 'POST',
-      headers: authHeader,
-      body: formData,
-    })
-    if (response.ok) {
-      const data = await response.json()
-      setFiles([...files, data])
-    }
-    e.target.value = ''
-  }
+  const authHeader = token ? { Authorization: `Token ${token}` } : undefined
 
   const handleSignOut = () => {
     localStorage.removeItem('token')
@@ -50,7 +28,7 @@ export default function DocumentManager() {
   const handleDownload = async () => {
     if (!selectedFile) return
     const response = await fetch(`/api/file_versions/${selectedFile.id}/download/`, {
-      headers: authHeader,
+      ...(authHeader ? { headers: authHeader } : {}),
     })
     if (response.ok) {
       const blob = await response.blob()
@@ -88,10 +66,9 @@ export default function DocumentManager() {
       </Box>
       <Box display="flex" flexDirection="column" flexGrow={1} sx={{ width: '64ch' }}>
         <Box mb={2} display="flex" justifyContent="space-between" alignItems="center">
-          <Box>
-            <Button variant="contained" onClick={triggerUpload}>Upload</Button>
-            <input ref={fileInputRef} type="file" hidden onChange={handleUpload} />
-          </Box>
+          <Button variant="contained" disabled>
+            Upload
+          </Button>
           <Button variant="contained" onClick={handleDownload} disabled={!selectedFile}>Download</Button>
         </Box>
         <Box flexGrow={1} display="flex" flexDirection="column">

--- a/src/propylon_document_manager/file_versions/api/views.py
+++ b/src/propylon_document_manager/file_versions/api/views.py
@@ -10,7 +10,6 @@ from rest_framework.mixins import RetrieveModelMixin, ListModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
-from django.db.models import Max
 
 from ..models import FileVersion
 from .serializers import FileVersionSerializer
@@ -21,31 +20,6 @@ class FileVersionViewSet(RetrieveModelMixin, ListModelMixin, GenericViewSet):
     serializer_class = FileVersionSerializer
     queryset = FileVersion.objects.all()
     lookup_field = "id"
-
-    @action(detail=False, methods=["post"], url_path="upload")
-    def upload(self, request):
-        uploaded_file = request.FILES.get("file")
-        if not uploaded_file:
-            return Response({"detail": "No file provided."}, status=status.HTTP_400_BAD_REQUEST)
-
-        file_name = uploaded_file.name
-        base_name, ext = os.path.splitext(file_name)
-        last_version = (
-            FileVersion.objects.filter(file_name=file_name).aggregate(max_v=Max("version_number"))
-        )["max_v"]
-        version_number = 0 if last_version is None else last_version + 1
-
-        storage_dir = Path(settings.FILES_ROOT)
-        storage_dir.mkdir(parents=True, exist_ok=True)
-        filename_with_version = f"{base_name}.{version_number}{ext}"
-        storage_path = storage_dir / filename_with_version
-        with open(storage_path, "wb+") as destination:
-            for chunk in uploaded_file.chunks():
-                destination.write(chunk)
-
-        file_version = FileVersion.objects.create(file_name=file_name, version_number=version_number)
-        serializer = self.get_serializer(file_version)
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["get"], url_path="download")
     def download(self, request, id=None):


### PR DESCRIPTION
## Summary
- remove the upload handler, hidden input, and trigger logic from the DocumentManager page and disable the Upload button
- adjust download requests to only include authorization headers when available
- drop the upload action from the FileVersion viewset so the backend no longer exposes the upload endpoint

## Testing
- pytest *(fails: Django dependency missing; pip install blocked by proxy errors)*
- npm run build *(fails: existing TypeScript errors in test files for jest-dom matchers)*

------
https://chatgpt.com/codex/tasks/task_e_68c83beebd74832e84995600bc93b25b