### PR TITLE
Add digest hex field to file versions

### DIFF
--- a/src/propylon_document_manager/file_versions/migrations/0007_fileversion_digest_hex.py
+++ b/src/propylon_document_manager/file_versions/migrations/0007_fileversion_digest_hex.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("file_versions", "0006_remove_userfileversion_datestamps"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="fileversion",
+            name="digest_hex",
+            field=models.CharField(
+                blank=True,
+                help_text="SHA-256 digest for the stored file in hexadecimal format.",
+                max_length=64,
+                null=True,
+            ),
+        ),
+    ]

--- a/src/propylon_document_manager/file_versions/models.py
+++ b/src/propylon_document_manager/file_versions/models.py
@@ -34,6 +34,12 @@ class User(AbstractUser):
 class FileVersion(models.Model):
     file_name = models.fields.CharField(max_length=512)
     version_number = models.fields.IntegerField()
+    digest_hex = models.fields.CharField(
+        max_length=64,
+        blank=True,
+        null=True,
+        help_text="SHA-256 digest for the stored file in hexadecimal format.",
+    )
 
 
 class UserFileVersion(models.Model):

--- a/tests/test_file_versions.py
+++ b/tests/test_file_versions.py
@@ -4,21 +4,26 @@ from .factories import UserFactory
 def test_file_versions():
     file_name = "new_file"
     file_version = 1
+    digest_hex = "0" * 64
     FileVersion.objects.create(
         file_name=file_name,
-        version_number=file_version
+        version_number=file_version,
+        digest_hex=digest_hex,
     )
     files = FileVersion.objects.all()
     assert files.count() == 1
     assert files[0].file_name == file_name
     assert files[0].version_number == file_version
+    assert files[0].digest_hex == digest_hex
 
 
 def test_user_fileversion():
     user = UserFactory()
     file_version = FileVersion.objects.create(
-        file_name="another_file", version_number=0
+        file_name="another_file",
+        version_number=0,
     )
     mapping = UserFileVersion.objects.create(fileversion=file_version, user=user)
     assert mapping.fileversion == file_version
     assert mapping.user == user
+    assert mapping.fileversion.digest_hex is None


### PR DESCRIPTION
## Summary
- add an optional `digest_hex` field to `FileVersion` for storing SHA-256 digests and expose it through the existing model serializers
- create a schema migration that adds the `digest_hex` column to `file_versions_fileversion`
- extend the file version tests to cover the new field

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c88458bbc8832ea04e50f5d032600b