### PR TITLE
Add file upload processing endpoint

### DIFF
--- a/src/propylon_document_manager/site/api_router.py
+++ b/src/propylon_document_manager/site/api_router.py
@@ -1,7 +1,8 @@
 from django.conf import settings
+from django.urls import path
 from rest_framework.routers import DefaultRouter, SimpleRouter
 
-from propylon_document_manager.file_versions.api.views import FileVersionViewSet
+from propylon_document_manager.file_versions.api.views import FileUploadView, FileVersionViewSet
 
 if settings.DEBUG:
     router = DefaultRouter()
@@ -12,4 +13,6 @@ router.register("file_versions", FileVersionViewSet)
 
 
 app_name = "api"
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path("file-uploads/", FileUploadView.as_view(), name="file-upload"),
+]

--- a/src/propylon_document_manager/utils/__init__.py
+++ b/src/propylon_document_manager/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the Propylon Document Manager project."""
+
+from .file_upload import FileUpload
+
+__all__ = ["FileUpload"]

--- a/src/propylon_document_manager/utils/file_upload.py
+++ b/src/propylon_document_manager/utils/file_upload.py
@@ -1,0 +1,33 @@
+"""Utilities for handling file uploads."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Union
+
+
+class FileUpload:
+    """Read a file and calculate its SHA-256 digest."""
+
+    def __init__(self, filepath: Union[str, Path]):
+        if not filepath:
+            raise ValueError("A file path must be provided.")
+
+        self.filepath = Path(filepath)
+        if not self.filepath.exists():
+            raise FileNotFoundError(f"File not found: {self.filepath}")
+        if not self.filepath.is_file():
+            raise ValueError(f"The path does not point to a file: {self.filepath}")
+
+        self.digest_hex = self._calculate_digest()
+
+    def _calculate_digest(self) -> str:
+        hasher = hashlib.sha256()
+        with self.filepath.open("rb") as file_obj:
+            for chunk in iter(lambda: file_obj.read(8192), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
+
+
+__all__ = ["FileUpload"]

--- a/tests/test_file_versions.py
+++ b/tests/test_file_versions.py
@@ -1,4 +1,10 @@
+import hashlib
+
+import pytest
+from rest_framework.test import APIClient
+
 from propylon_document_manager.file_versions.models import FileVersion, UserFileVersion
+from propylon_document_manager.utils import FileUpload
 from .factories import UserFactory
 
 def test_file_versions():
@@ -27,3 +33,45 @@ def test_user_fileversion():
     assert mapping.fileversion == file_version
     assert mapping.user == user
     assert mapping.fileversion.digest_hex is None
+
+
+def test_file_upload_computes_digest(tmp_path):
+    file_path = tmp_path / "example.txt"
+    file_path.write_text("sample content")
+
+    uploader = FileUpload(file_path)
+
+    expected_digest = hashlib.sha256(b"sample content").hexdigest()
+    assert uploader.digest_hex == expected_digest
+
+
+@pytest.mark.django_db
+def test_file_upload_view_returns_digest(user, tmp_path):
+    file_path = tmp_path / "upload.txt"
+    file_path.write_text("data for digest")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/file-uploads/",
+        {"filepath": str(file_path)},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["digest_hex"] == hashlib.sha256(b"data for digest").hexdigest()
+
+
+@pytest.mark.django_db
+def test_file_upload_view_handles_missing_file(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/file-uploads/",
+        {"filepath": "/tmp/non-existent-file"},
+        format="json",
+    )
+
+    assert response.status_code == 404
+    assert "detail" in response.json()


### PR DESCRIPTION
## Summary
- add a FileUpload utility that reads a file from disk and calculates its SHA-256 digest
- create FileUploadView to handle POST/PUT requests and return the computed digest
- register the upload endpoint and cover the utility and view with tests

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'django' in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c887e04644832eb9a8b81601f1c750