### PR TITLE
Implement latest version lookup for FileUpload

### DIFF
--- a/src/propylon_document_manager/utils/file_upload.py
+++ b/src/propylon_document_manager/utils/file_upload.py
@@ -6,6 +6,8 @@ import hashlib
 from pathlib import Path
 from typing import Union
 
+from django.db.models import Max
+
 
 class FileUpload:
     """Read a file and calculate its SHA-256 digest."""
@@ -38,6 +40,22 @@ class FileUpload:
             return False
 
         return FileVersion.objects.filter(digest_hex=self.digest_hex).exists()
+
+    def get_latest_version(self) -> int:
+        """Return the next version number for the current file."""
+
+        from propylon_document_manager.file_versions.models import FileVersion
+
+        latest_version = (
+            FileVersion.objects.filter(file_name=str(self.filepath))
+            .aggregate(max_version=Max("version_number"))
+            .get("max_version")
+        )
+
+        if latest_version is None:
+            return 0
+
+        return latest_version + 1
 
 
 __all__ = ["FileUpload"]


### PR DESCRIPTION
## Summary
- add an aggregate query to FileUpload for determining the next version number
- default to version 0 when no stored versions exist for the file path

## Testing
- pytest tests/test_file_versions.py *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c89024f5c4832e88efcbe1bd3c1671