### PR TITLE
Add FileDownload utility for retrieving file version metadata

### DIFF
--- a/src/propylon_document_manager/utils/__init__.py
+++ b/src/propylon_document_manager/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility helpers for the Propylon Document Manager project."""
 
+from .file_download import FileDownload
 from .file_upload import FileUpload
 
-__all__ = ["FileUpload"]
+__all__ = ["FileDownload", "FileUpload"]

--- a/src/propylon_document_manager/utils/file_download.py
+++ b/src/propylon_document_manager/utils/file_download.py
@@ -1,0 +1,68 @@
+"""Utilities for retrieving stored file version details."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Optional, Union
+
+from django.db.models import Max
+
+
+class FileDownload:
+    """Fetch metadata for stored file versions."""
+
+    def __init__(self, filepath: Union[str, Path], version: Optional[int] = None):
+        if not filepath:
+            raise ValueError("A file path must be provided.")
+
+        self.filepath = str(filepath)
+        if version is not None:
+            if version < 0:
+                raise ValueError("Version must be a non-negative integer.")
+            self.version = int(version)
+        else:
+            self.version = None
+    def _get_max_version(self, filepath: Optional[Union[str, Path]] = None) -> int:
+        """Return the latest stored version number for the file."""
+
+        from propylon_document_manager.file_versions.models import FileVersion
+
+        target_path = self.filepath if filepath is None else str(filepath)
+        result = (
+            FileVersion.objects.filter(file_name=target_path)
+            .aggregate(max_version=Max("version_number"))
+            .get("max_version")
+        )
+
+        if result is None:
+            raise FileVersion.DoesNotExist(
+                f"No versions found for file: {target_path}"
+            )
+
+        return int(result)
+
+    def _get_file_data(
+        self, filepath: Union[str, Path], version: Optional[int]
+    ) -> Mapping[str, Any]:
+        """Return the database row for the requested file version."""
+
+        from propylon_document_manager.file_versions.models import FileVersion
+
+        target_path = str(filepath)
+        resolved_version = (
+            self._get_max_version(target_path)
+            if version is None
+            else int(version)
+        )
+
+        try:
+            return FileVersion.objects.values().get(
+                file_name=target_path, version_number=resolved_version
+            )
+        except FileVersion.DoesNotExist as exc:
+            raise FileVersion.DoesNotExist(
+                f"No file version found for {target_path} with version {resolved_version}."
+            ) from exc
+
+
+__all__ = ["FileDownload"]

--- a/tests/test_utils_file_download.py
+++ b/tests/test_utils_file_download.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import pytest
+
+from propylon_document_manager.file_versions.models import FileVersion
+from propylon_document_manager.utils import FileDownload
+
+
+@pytest.mark.django_db
+def test_get_max_version_returns_highest_value(tmp_path: Path):
+    file_path = tmp_path / "example.txt"
+    FileVersion.objects.create(file_name=str(file_path), version_number=0)
+    FileVersion.objects.create(file_name=str(file_path), version_number=3)
+
+    downloader = FileDownload(filepath=str(file_path))
+
+    assert downloader._get_max_version() == 3
+
+
+@pytest.mark.django_db
+def test_get_max_version_raises_when_missing(tmp_path: Path):
+    downloader = FileDownload(filepath=str(tmp_path / "missing.txt"))
+
+    with pytest.raises(FileVersion.DoesNotExist):
+        downloader._get_max_version()
+
+
+@pytest.mark.django_db
+def test_get_file_data_defaults_to_latest_version(tmp_path: Path):
+    file_path = tmp_path / "history.txt"
+    FileVersion.objects.create(file_name=str(file_path), version_number=0)
+    latest = FileVersion.objects.create(
+        file_name=str(file_path),
+        version_number=1,
+        digest_hex="b" * 64,
+    )
+
+    downloader = FileDownload(filepath=str(file_path))
+
+    record = downloader._get_file_data(filepath=str(file_path), version=None)
+
+    assert record["id"] == latest.id
+    assert record["version_number"] == 1
+
+
+@pytest.mark.django_db
+def test_get_file_data_raises_when_not_found(tmp_path: Path):
+    file_path = tmp_path / "unknown.txt"
+    downloader = FileDownload(filepath=str(file_path))
+
+    with pytest.raises(FileVersion.DoesNotExist):
+        downloader._get_file_data(filepath=str(file_path), version=0)


### PR DESCRIPTION
## Summary
- add a FileDownload helper capable of retrieving metadata for stored file versions
- expose the new download utility via the utils package
- cover the new utility with tests for key behaviours

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'django')*
- pip install -r requirements/dev.txt *(fails: Cannot connect to proxy: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c899c613a8832e93500f855fa1f5ed