### PR TITLE
Add file download utility

### DIFF
--- a/src/propylon_document_manager/utils/file_download.py
+++ b/src/propylon_document_manager/utils/file_download.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 from typing import Any, Mapping, Optional, Union
 
+from django.conf import settings
 from django.db.models import Max
 
 
@@ -22,6 +24,12 @@ class FileDownload:
             self.version = int(version)
         else:
             self.version = None
+
+    def get_file_data(self) -> Mapping[str, Any]:
+        """Return metadata for the configured file path and version."""
+
+        return self._get_file_data(filepath=self.filepath, version=self.version)
+
     def _get_max_version(self, filepath: Optional[Union[str, Path]] = None) -> int:
         """Return the latest stored version number for the file."""
 
@@ -63,6 +71,39 @@ class FileDownload:
             raise FileVersion.DoesNotExist(
                 f"No file version found for {target_path} with version {resolved_version}."
             ) from exc
+
+    def download(self) -> str:
+        """Retrieve the stored file and save it to the configured path."""
+
+        from propylon_document_manager.file_versions.models import FileVersion
+
+        try:
+            file_data = self.get_file_data()
+        except FileVersion.DoesNotExist:
+            return "That file does not exist on the server"
+
+        if not file_data:
+            return "That file does not exist on the server"
+
+        digest_hex = file_data.get("digest_hex")
+        if not digest_hex:
+            return "That file does not exist on the server"
+
+        storage_directory = Path(settings.FILES_ROOT)
+        source_path = storage_directory / digest_hex
+
+        if not source_path.exists() or not source_path.is_file():
+            return "That file does not exist on the server"
+
+        destination_path = Path(self.filepath)
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            shutil.copy2(source_path, destination_path)
+        except OSError as exc:
+            return f"Error downloading {destination_path}: {exc}"
+
+        return f"File {destination_path} downloaded successfully"
 
 
 __all__ = ["FileDownload"]


### PR DESCRIPTION
## Summary
- add a public helper for retrieving file metadata within `FileDownload`
- implement a download routine that copies the stored digest-named file to the requested path
- cover the new download workflow with tests for success and failure scenarios

## Testing
- pytest tests/test_utils_file_download.py *(fails: ModuleNotFoundError: No module named 'django' because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a2c4842c832ebaed590fdc46dbcf