### PR TITLE
Add user factory fixture for account login test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,16 @@ def media_storage(settings, tmpdir):
 @pytest.fixture
 def user(db) -> User:
     return UserFactory()
+
+
+@pytest.fixture
+def user_factory(db):
+    """Return a callable that creates users with optional custom fields."""
+
+    def factory(**kwargs) -> User:
+        password = kwargs.pop("password", None)
+        if password is not None:
+            return UserFactory(password=password, **kwargs)
+        return UserFactory(**kwargs)
+
+    return factory


### PR DESCRIPTION
## Summary
- add a `user_factory` pytest fixture so tests can create users with custom passwords for login checks

## Testing
- pytest tests/test_accounts.py::test_user_can_login *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c8a92df7ac832e9c4303ffba9c2e6a